### PR TITLE
Change search event from 'keyup' to 'change'

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -146,7 +146,7 @@ $(document).ready(function() {
 
     //keyup for input search
 
-    $("input").keyup(function() {
+    $("input").change(function() {
 
         var $val = $(this).val().toLowerCase();
         var $photos = $(".photogallery a").find("img");


### PR DESCRIPTION
#### Keyup fires fadeIn() too many times

Hey dude, looks great! Just messing around I noticed that 'keyup' is bound to the search field. Obviously it looks great, but the version you have now will fadeIn() each image as many times as characters you type (for example, typing in 'plantation' to the search bar will flash the plantation image 11 times).

My solution, the change event, requires the user to press enter or to focus out of the text box (Screw that!), and should only be a temporary solution. 

I've been looking around for ways to fix this, haven't found anything yet. Just thought I'd bring it to your attention. I'll keep looking, and let me know if/when you figure it out!
